### PR TITLE
Corrected publication year of Lu (2016) in many files.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Description: Computation of key characteristics and plots for blinded sample siz
    Continuous as well as binary endpoints are supported in superiority and non-inferiority trials.
    See Baumann, Pilz, Kieser (2022) <doi:10.32614/RJ-2022-001> for a detailed description.
    The implemented methods include the approaches by
-   Lu, K. (2019) <doi:10.1002/pst.1737>,
+   Lu, K. (2016) <doi:10.1002/pst.1737>,
    Kieser, M. and Friede, T. (2000) <doi:10.1002/(SICI)1097-0258(20000415)19:7%3C901::AID-SIM405%3E3.0.CO;2-L>,
    Friede, T. and Kieser, M. (2004) <doi:10.1002/pst.140>, 
    Friede, T., Mitchell, C., Mueller-Veltern, G. (2007) <doi:10.1002/bimj.200610373>, and

--- a/R/Student.R
+++ b/R/Student.R
@@ -16,11 +16,11 @@
 #' @return Simulated rejection probabilities and sample sizes for
 #'    each nuisance parameter.
 #'
-#' @details The implementation follows the algorithm in Lu (2019):
+#' @details The implementation follows the algorithm in Lu (2016):
 #' Distribution of the two-sample t-test statistic following blinded
 #' sample size re-estimation.
 #' Pharmaceutical Statistics 15: 208-215.
-#' Since Lu (2019) assumes negative non-inferiority margins, the non-inferiority
+#' Since Lu (2016) assumes negative non-inferiority margins, the non-inferiority
 #' margin of \code{design} is multiplied with -1 internally.
 #'
 #' @examples
@@ -52,7 +52,7 @@ simulation <- function(design, n1, nuisance, recalculation = TRUE, delta_true,
   }
   alloc <- design@r / (1 + design@r)^2
 
-  # the following implements the 5 steps of the algorithm by Lu (2019), p.210
+  # the following implements the 5 steps of the algorithm by Lu (2016), p.210
   ## Step 1
   z1 <- stats::rnorm(n = iters, mean = 0, sd = 1)
   v1 <- stats::rchisq(n = iters, df = n1 - 2)

--- a/R/test_statistics.R
+++ b/R/test_statistics.R
@@ -36,7 +36,7 @@ setClass("TestStatistic", slots = c(
 #' \code{\link{adjusted_alpha}}, and \code{\link{n_fix}}.
 #' Check the design specific documentation for details.
 #'
-#' @references Lu, K. (2019).
+#' @references Lu, K. (2016).
 #' Distribution of the two-sample t-test statistic following blinded
 #' sample size re-estimation. Pharmaceutical Statistics 15(3): 208-215.
 #'

--- a/man/Student.Rd
+++ b/man/Student.Rd
@@ -76,7 +76,7 @@ d <- setupStudent(alpha = .025, beta = .2, r = 1, delta = 3.5, delta_NI = 0,
                   alternative = "greater", n_max = 156)
 }
 \references{
-Lu, K. (2019).
+Lu, K. (2016).
 Distribution of the two-sample t-test statistic following blinded
 sample size re-estimation. Pharmaceutical Statistics 15(3): 208-215.
 }

--- a/man/simulation.Rd
+++ b/man/simulation.Rd
@@ -52,11 +52,11 @@ Note that here the nuisance parameter \code{nuisance} is the variance
 of the outcome variable sigma^2.
 }
 \details{
-The implementation follows the algorithm in Lu (2019):
+The implementation follows the algorithm in Lu (2016):
 Distribution of the two-sample t-test statistic following blinded
 sample size re-estimation.
 Pharmaceutical Statistics 15: 208-215.
-Since Lu (2019) assumes negative non-inferiority margins, the non-inferiority
+Since Lu (2016) assumes negative non-inferiority margins, the non-inferiority
 margin of \code{design} is multiplied with -1 internally.
 }
 \examples{

--- a/tests/testthat/test_t_test.R
+++ b/tests/testthat/test_t_test.R
@@ -2,7 +2,7 @@ context("test t-test")
 
 its <- 1e5
 
-test_that("Examples of Lu (2019) can be reproduced", {
+test_that("Examples of Lu (2016) can be reproduced", {
   set.seed(123)
   design1 <- setupStudent(alpha = .025, beta = .2, r = 1, delta = 3.5,
                          delta_NI = 0, n_max = Inf)


### PR DESCRIPTION
The algorithm for calculating rejection probabilities is from the paper Lu (2016). The year is correctly specified in the blindrecalc paper, but in much of the code and documentation, it is spuriously labeled Lu (2019).